### PR TITLE
Update react peer dependency to support version 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",


### PR DESCRIPTION
In the readme it is written "Ready to React 18", but the `package.json` doesn't list version 18. Thus, trying to install it along react 18 ends up in the following error message:
`npm i react-image-picker-editor`
```text
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: my-demo-project@0.0.0
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.2" from react-image-picker-editor@1.3.5
npm ERR! node_modules/react-image-picker-editor
npm ERR!   react-image-picker-editor@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```